### PR TITLE
Fix tls connection options

### DIFF
--- a/config/elasticsearch.ini
+++ b/config/elasticsearch.ini
@@ -18,7 +18,7 @@
 ; username: haraka
 ; password: nice-long-pass-phrase
 
-; [ssl]
+; [tls]
 ; rejectUnauthorized=false
 
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ exports.get_es_hosts = function () {
 
     plugin.clientArgs = { nodes: plugin.cfg.es_hosts };
     if (plugin.cfg.auth) plugin.clientArgs.auth = plugin.cfg.auth;
-    if (plugin.cfg.ssl)  plugin.clientArgs.ssl = plugin.cfg.ssl;
+    if (plugin.cfg.tls)  plugin.clientArgs.tls = plugin.cfg.tls;
 }
 
 exports.es_connect = function (done) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-elasticsearch",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Haraka plugin that saves logs to Elasticsearch",
   "main": "index.js",
   "scripts": {

--- a/test/config.js
+++ b/test/config.js
@@ -53,7 +53,7 @@ describe('get_es_hosts', function () {
         done();
     })
 
-    it('applies auth & ssl config to client config', function (done) {
+    it('applies auth & tls config to client config', function (done) {
         console.log(this.plugin.cfg);
         this.plugin.config.root_path = path.resolve('test', 'fixtures');
         this.plugin.load_es_ini();
@@ -67,7 +67,7 @@ describe('get_es_hosts', function () {
                 "https://user:password@172.16.10.1:9200",
                 "http://127.0.0.1:9200"
             ],
-            "ssl": {
+            "tls": {
                 "rejectUnauthorized": false
             }
         });

--- a/test/fixtures/elasticsearch.ini
+++ b/test/fixtures/elasticsearch.ini
@@ -19,7 +19,7 @@
 username=haraka
 password=nice-long-pass-phrase
 
-[ssl]
+[tls]
 rejectUnauthorized=false
 
 


### PR DESCRIPTION
SSL option to disable certificate check was ignored. The connection option is "tls", not "ssl".

https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.8/client-connecting.html#auth-tls



