### PR TITLE
Added support for Cloud ID and the "@timestamp" field

### DIFF
--- a/config/elasticsearch.ini
+++ b/config/elasticsearch.ini
@@ -14,9 +14,18 @@
 ; Ex: 172.16.10.1=https://user:password@172.16.10.1:9200
 127.0.0.1
 
+; Provide a Cloud ID to log to an Elastic Cloud instance
+; The Cloud ID setting will override any hosts listed above
+; Remember to also create an API key and provide it under [auth] below
+; [cloud]
+; id=PROJECT-NAME:Long-base64-string
+
 ; [auth]
 ; username=haraka
 ; password=nice-long-pass-phrase
+; You can also use apiKey or token
+; apiKey=base64-string
+; bearer=token
 
 ; [tls]
 ; rejectUnauthorized=false
@@ -45,6 +54,9 @@
 ;   year : smtp-connection-2025
 interval=day
 
+; use modern timestamp field
+; Switches the indexing to use the '@timestamp' field instead of 'timestamp'
+modern_timestamp=true
 
 ; At the top level, each ES document has three categories: connection, message,
 ; and plugins. Those names can be customized here.


### PR DESCRIPTION
## Changes in config/elasticsearch.ini

- Added a [cloud] section where you can put the Cloud ID (id=cloud-id) in order to get Haraka to log to Elastic Cloud. PS! This also requires you to add apiKey=xxx in [auth].
- Added modern_timestamp=true under [index]. When set to true, the plugin uses the field '@timestamp' to log the date. Set to false to revert to 'timestamp'.

## Changes in index.js

- Moved setting the plugin's clientArgs to **load_es_ini**, instead of inside **get_es_hosts**. It seems a bit cleaner, and it also allows the cloud.id to override the hosts setting.
- load_es_ini also sets the plugin's cfg.tsField according to the cfg.index.modern_timestamp setting.
- log_transaction and log_connection uses cfg.tsField to decide the timestamp field name